### PR TITLE
Run nix-build in CI

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,6 +1,8 @@
 name: Nix CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -12,3 +12,5 @@ jobs:
     - uses: cachix/cachix-action@v3  # This also runs nix-build.
       with:
         name: srid
+    - name: Build
+      run: nix-build


### PR DESCRIPTION
I think `cachix-action` runs it only when there is push access to the cache. There isn't one in this repo, so I guess that's why it is not running nix-build. In any case, it is better to run it explicitly.

Let's wait and see if the CI for this PR in fact runs nix-build.