### PR TITLE
Update rib, for simplified API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist-newstyle/
 .shake/
 dist/dante/
+
+# Nix
+result

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,12 @@
 let
   ribRevision = "a57e7ab7ef5b5b5fcbbf7b99b3edb33bfde5851f";
+
+  inherit (import (builtins.fetchTarball "https://github.com/hercules-ci/gitignore/archive/7415c4f.tar.gz") { }) gitignoreSource;
 in {
 # Rib library source to use
   rib ? builtins.fetchTarball "https://github.com/srid/rib/archive/${ribRevision}.tar.gz"
 # Cabal project root
-, root ? ./.
+, root ? gitignoreSource ./.
 # Cabal project name
 , name ? "open-editions-org"
 , ...

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 let
-  ribRevision = "ca3e9fbd1befbca868d3254559805eacba78e7eb";
+  ribRevision = "a57e7ab7ef5b5b5fcbbf7b99b3edb33bfde5851f";
 in {
 # Rib library source to use
   rib ? builtins.fetchTarball "https://github.com/srid/rib/archive/${ribRevision}.tar.gz"


### PR DESCRIPTION
We forked `buildHtmlMulti` and customized it to be able to have 'clean URLs'. This is no longer necessary with the new `forEvery` API.